### PR TITLE
fix: remove APK_GIT references from workflows and documentation

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -37,7 +37,6 @@ jobs:
           build_args: |
             RUBYGEM_R10K=${{ matrix.rubygem_r10k }}
             RUBYGEM_PUPPET=${{ matrix.rubygem_puppet }}
-            APK_GIT=${{ matrix.apk_git }}
           build_arch: linux/amd64,linux/arm64
           docker_username: voxpupulibot
           docker_password: ${{ secrets.DOCKERHUB_BOT_PASSWORD }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,6 @@ jobs:
           build-args: |
             RUBYGEM_R10K=${{ matrix.rubygem_r10k }}
             RUBYGEM_PUPPET=${{ matrix.rubygem_puppet }}
-            APK_GIT=${{ matrix.apk_git }}
 
       - name: Test container
         run: docker run --rm ci/r10k:${{ matrix.rubygem_r10k }} deploy environment -mv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM alpine:3.20
 
-ARG APK_GIT=2.45.2-r0
 ARG RUBYGEM_R10K=5.0.0
 ARG RUBYGEM_PUPPET=8.10.0
 
@@ -28,7 +27,7 @@ RUN apk update \
     && apk add --no-cache \
       bash \
       gcc \
-      git=${APK_GIT} \
+      git \
       libssh2 \
       make \
       musl-dev \

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ services:
 
 | Name | Description |
 | ---- | ------------|
-|`APK_GIT`| The git version to install |
 |`RUBYGEM_R10K`| The r10k version to install |
 |`RUBYGEM_PUPPET`| The puppet version to install |
 |`PUPPET_CONTROL_REPO` | The control repo url to get the Puppetfile from. Defaults to https://github.com/voxpupuli/controlrepo.git |

--- a/build_versions.json
+++ b/build_versions.json
@@ -2,8 +2,7 @@
   "include": [
     {
       "rubygem_r10k": "5.0.0",
-      "rubygem_puppet": "8.10.0",
-      "apk_git": "2.45.2-r0"
+      "rubygem_puppet": "8.10.0"
     }
   ]
 }


### PR DESCRIPTION
we have no benefit in pinning git. let's just use latest default here. otherwise this will break if package ist updatet or alpine ist updatet. they dont keep older versions.