### PR TITLE
Move default for PUPPET_CONTROL_REPO into entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM alpine:3.21
 ARG RUBYGEM_R10K=5.0.0
 ARG RUBYGEM_PUPPET=8.10.0
 
-ARG PUPPET_CONTROL_REPO="https://github.com/voxpupuli/controlrepo.git"
-ENV PUPPET_CONTROL_REPO=$PUPPET_CONTROL_REPO
+ARG DEFAULT_CONTROL_REPO="https://github.com/voxpupuli/controlrepo.git"
 
 ARG UID=999
 # in alpine 3.20 "ping" is the group of id 999

--- a/r10k/docker-entrypoint.d/create_r10k_config.sh
+++ b/r10k/docker-entrypoint.d/create_r10k_config.sh
@@ -12,5 +12,5 @@ cachedir: "/opt/puppetlabs/puppet/cache/r10k"
 sources:
   puppet:
     basedir: "/etc/puppetlabs/code/environments"
-    remote: ${PUPPET_CONTROL_REPO}
+    remote: ${PUPPET_CONTROL_REPO:=$DEFAULT_CONTROL_REPO}
 EOF


### PR DESCRIPTION
ARG is while image build time, ENV while container create.