### PR TITLE
feat: Add Supercronic support

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
 ARG RUBYGEM_R10K=5.0.0
 ARG RUBYGEM_OPENVOX=8.21.1
 ARG SUPERCRONIC_VERSION=v0.2.45
-ARG  SUPERCRONIC_BASE_URL=https://github.com/aptible/supercronic/releases/download
+ARG SUPERCRONIC_BASE_URL=https://github.com/aptible/supercronic/releases/download
 
 FROM docker.io/library/alpine:3.23 AS builder
 ARG RUBYGEM_R10K

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,7 @@
 ARG RUBYGEM_R10K=5.0.0
 ARG RUBYGEM_OPENVOX=8.21.1
+ARG SUPERCRONIC_VERSION=v0.2.45
+ARG  SUPERCRONIC_BASE_URL=https://github.com/aptible/supercronic/releases/download
 
 FROM docker.io/library/alpine:3.23 AS builder
 ARG RUBYGEM_R10K
@@ -49,6 +51,30 @@ RUN mkdir -p /etc/puppetlabs/r10k /opt/puppetlabs/bin /opt/puppetlabs/puppet/cac
     && ln -s "/usr/lib/ruby/gems/3.4.0/gems/r10k-${RUBYGEM_R10K}/bin/r10k" /usr/local/bin/r10k \
     && ln -s "/usr/lib/ruby/gems/3.4.0/gems/openvox-${RUBYGEM_OPENVOX}/bin/puppet" /opt/puppetlabs/bin/puppet \
     && chmod +x /container-entrypoint.sh /container-entrypoint.d/*.sh
+
+
+
+RUN set -eux; \
+    ARCH="${TARGETARCH:-$(uname -m)}"; \
+    case "${ARCH}" in \
+      amd64|x86_64) \
+        SUPERCRONIC_BIN="supercronic-linux-amd64"; \
+        SUPERCRONIC_SHA1SUM="e894b193bea75a5ee644e700c59e30eedc804cf7"; \
+        ;; \
+      arm64|aarch64) \
+        SUPERCRONIC_BIN="supercronic-linux-arm64"; \
+        SUPERCRONIC_SHA1SUM="20ce6dace414a64f0632f4092d6d3745db6085ad"; \
+        ;; \
+      *) \
+        echo "Unsupported architecture: ${ARCH}"; \
+        exit 1; \
+        ;; \
+    esac; \
+    curl -fsSLO "${SUPERCRONIC_BASE_URL}/${SUPERCRONIC_VERSION}/${SUPERCRONIC_BIN}" \
+    && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC_BIN}" | sha1sum -c - \
+    && chmod +x "${SUPERCRONIC_BIN}" \
+    && mv "${SUPERCRONIC_BIN}" "/usr/local/bin/${SUPERCRONIC_BIN}" \
+    && ln -s "/usr/local/bin/${SUPERCRONIC_BIN}" /usr/local/bin/supercronic
 
 USER puppet
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,5 @@
 ARG RUBYGEM_R10K=5.0.0
 ARG RUBYGEM_OPENVOX=8.21.1
-ARG SUPERCRONIC_VERSION=v0.2.45
-ARG SUPERCRONIC_BASE_URL=https://github.com/aptible/supercronic/releases/download
 
 FROM docker.io/library/alpine:3.23 AS builder
 ARG RUBYGEM_R10K
@@ -52,7 +50,8 @@ RUN mkdir -p /etc/puppetlabs/r10k /opt/puppetlabs/bin /opt/puppetlabs/puppet/cac
     && ln -s "/usr/lib/ruby/gems/3.4.0/gems/openvox-${RUBYGEM_OPENVOX}/bin/puppet" /opt/puppetlabs/bin/puppet \
     && chmod +x /container-entrypoint.sh /container-entrypoint.d/*.sh
 
-
+ARG SUPERCRONIC_VERSION=v0.2.45
+ARG SUPERCRONIC_BASE_URL=https://github.com/aptible/supercronic/releases/download
 
 RUN set -eux; \
     ARCH="${TARGETARCH:-$(uname -m)}"; \


### PR DESCRIPTION
this brings back cron functionality that existed in the puppet builds of r10k container as used by the helmchart - fixes #52 and also https://github.com/OpenVoxProject/openvox-helm-chart/issues/28

this is done in such a way as to support both x86_64 and arm64 builds as well as checks against the sha1sum for download verification - note that in future you have to update both the version tag and the sha1 hashes from the supercronic github release page https://github.com/aptible/supercronic

openvox-helm-chart will also need a version bump for the new image version